### PR TITLE
Fix FOUC on first load

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,9 +1,30 @@
 import Document, { Html, Head, Main, NextScript } from "next/document";
+import { ServerStyleSheet } from "styled-components";
 
 class MyDocument extends Document {
   static async getInitialProps(ctx) {
-    const initialProps = await Document.getInitialProps(ctx);
-    return { ...initialProps };
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
+        });
+
+      const initialProps = await Document.getInitialProps(ctx);
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } finally {
+      sheet.seal();
+    }
   }
 
   render() {

--- a/src/components/partners/partner.js
+++ b/src/components/partners/partner.js
@@ -11,7 +11,7 @@ import "./types.d";
 const Partner = ({ bg, logo, name, url }) => (
   <Styles.Logo bg={bg}>
     <Link href={url} passHref>
-      <a target="_blank">
+      <a target="_blank" rel="noreferrer noopener">
         <img src={logo} alt={name} loading="lazy" />
       </a>
     </Link>


### PR DESCRIPTION
#### Because:
* The first load of the page always displays a _Flash of Unstyled Content_ (FOUC)

#### This commit: 
* Adds a Server-side fix by using SSR functionality within styled-components and applying it to `_document.js`.